### PR TITLE
Enhance UI layout and add New Game reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,32 +10,34 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <button id="new-game-button" class="primary-action">New Game</button>
     <div class="game-console white-team-theme">
         <div class="keywords-container">
-            <div class="keyword-slot"><span class="keyword-number">1</span>Castle</div>
-            <div class="keyword-slot"><span class="keyword-number">2</span>Forest</div>
-            <div class="keyword-slot"><span class="keyword-number">3</span>Dragon</div>
-            <div class="keyword-slot"><span class="keyword-number">4</span>Queen</div>
+            <div class="keyword-slot"><span class="keyword-number">1</span></div>
+            <div class="keyword-slot"><span class="keyword-number">2</span></div>
+            <div class="keyword-slot"><span class="keyword-number">3</span></div>
+            <div class="keyword-slot"><span class="keyword-number">4</span></div>
         </div>
 
-        <div class="code-generator-area">
-            <button class="floppy-disk-button"></button>
-            <div class="code-display" style="display: none;"></div>
-        </div>
-
-        <div class="tokens-area">
-            <div class="token-group">
-                <div>Interception</div>
-                <button class="token-button"><div class="token-display token-interception"></div></button>
-                <button class="token-button"><div class="token-display token-interception"></div></button>
+        <div class="middle-section">
+            <div class="code-generator-area">
+                <button class="floppy-disk-button"></button>
+                <div class="code-display" style="display: none;"></div>
             </div>
-            <div class="token-group">
-                <div>Miscommunication</div>
-                <button class="token-button"><div class="token-display token-miscommunication"></div></button>
+
+            <div class="tokens-area">
+                <div class="token-group">
+                    <div>Interception</div>
+                    <button class="token-button"><div class="token-display token-interception"></div></button>
+                    <button class="token-button"><div class="token-display token-interception"></div></button>
+                </div>
+                <div class="token-group">
+                    <div>Miscommunication</div>
+                    <button class="token-button"><div class="token-display token-miscommunication"></div></button>
+                    <button class="token-button"><div class="token-display token-miscommunication"></div></button>
+                </div>
             </div>
         </div>
-
-        <button class="primary-action new-round-button">New Round</button>
 
         <div class="encryptor-card">
             <input type="text" placeholder="Clue 1">

--- a/script.js
+++ b/script.js
@@ -3,25 +3,80 @@
 document.addEventListener('DOMContentLoaded', () => {
     const floppyButton = document.querySelector('.floppy-disk-button');
     const codeDisplay = document.querySelector('.code-display');
-    const newRoundButton = document.querySelector('.new-round-button');
+    const newGameButton = document.getElementById('new-game-button');
     const tokenButtons = document.querySelectorAll('.token-button');
     const clearButton = document.querySelector('.encryptor-card .clear-button');
     const clueInputs = document.querySelectorAll('.encryptor-card input');
+    const noteAreas = document.querySelectorAll('.opponent-notes-grid textarea');
+    const keywordSlots = document.querySelectorAll('.keyword-slot');
+
+    let wordBank = [];
+    let roundNumber = 1;
+
+    async function loadWordBank() {
+        if (wordBank.length) return;
+        const response = await fetch('keywords.json');
+        const data = await response.json();
+        wordBank = data.map(item => item.word);
+    }
+
+    function pickRandomWords(count = 4) {
+        const available = [...wordBank];
+        const selected = [];
+        for (let i = 0; i < count; i++) {
+            const idx = Math.floor(Math.random() * available.length);
+            selected.push(available.splice(idx, 1)[0]);
+        }
+        return selected;
+    }
+
+    function displayKeywords(words) {
+        keywordSlots.forEach((slot, i) => {
+            slot.innerHTML = `<span class="keyword-number">${i + 1}</span>${words[i] || ''}`;
+        });
+    }
+
+    function resetTokens() {
+        document.querySelectorAll('.token-display').forEach(td => td.classList.remove('active'));
+    }
+
+    function clearCluesAndNotes() {
+        clueInputs.forEach(input => input.value = '');
+        noteAreas.forEach(area => area.value = '');
+    }
+
+    async function startNewGame() {
+        await loadWordBank();
+        const words = pickRandomWords(4);
+        displayKeywords(words);
+        resetTokens();
+        codeDisplay.style.display = 'none';
+        floppyButton.style.display = 'block';
+        clearCluesAndNotes();
+        roundNumber = 1;
+    }
+
+    function generateRoundCode() {
+        const digits = [1, 2, 3, 4];
+        const code = [];
+        for (let i = 0; i < 3; i++) {
+            const idx = Math.floor(Math.random() * digits.length);
+            code.push(digits.splice(idx, 1)[0]);
+        }
+        return code;
+    }
 
     if (floppyButton) {
         floppyButton.addEventListener('click', () => {
-            const code = game.generate_round_code();
-            codeDisplay.textContent = Array.isArray(code) ? code.join('-') : code;
+            const code = generateRoundCode();
+            codeDisplay.textContent = code.join('-');
             codeDisplay.style.display = 'block';
             floppyButton.style.display = 'none';
         });
     }
 
-    if (newRoundButton) {
-        newRoundButton.addEventListener('click', () => {
-            codeDisplay.style.display = 'none';
-            floppyButton.style.display = 'block';
-        });
+    if (newGameButton) {
+        newGameButton.addEventListener('click', startNewGame);
     }
 
     tokenButtons.forEach(btn => {
@@ -36,4 +91,6 @@ document.addEventListener('DOMContentLoaded', () => {
             clueInputs.forEach(input => input.value = '');
         });
     }
+
+    startNewGame();
 });

--- a/style.css
+++ b/style.css
@@ -119,17 +119,27 @@ body {
 }
 
 /* Button to generate the code, styled like a floppy disk */
+
+/* Container for the floppy button and tokens */
+.middle-section {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
 .code-generator-area {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-bottom: 20px;
+    margin-right: 20px;
     min-height: 50px;
 }
 
 .floppy-disk-button {
-    width: 50px;
-    height: 50px;
+    width: 90px;
+    height: 90px;
+    flex-shrink: 0;
     background-color: #555;
     border: 2px solid #888;
     border-radius: 4px;
@@ -152,8 +162,9 @@ body {
 /* --- 5. Token Display --- */
 .tokens-area {
     display: flex;
-    justify-content: space-around;
-    margin-bottom: 20px;
+    justify-content: center;
+    gap: 20px;
+    flex-grow: 1;
 }
 .token-group {
     text-align: center;
@@ -295,5 +306,13 @@ button.primary-action {
 }
 button.primary-action:hover {
     background-color: #b00000;
+}
+
+/* Button above the console */
+#new-game-button {
+    display: block;
+    margin: 0 auto 20px auto;
+    padding: 10px 25px;
+    font-size: 1.2em;
 }
 


### PR DESCRIPTION
## Summary
- rearrange layout with a new middle section for the floppy button and tokens
- add a "New Game" button and second miscommunication token
- enlarge floppy button and improve styling for new layout
- load keywords dynamically from `keywords.json`
- implement full game reset in JavaScript when starting a new game

## Testing
- `python -m py_compile decrypto.py`
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_686dd2cbe6408327ac8f56194d9f13e0