### PR TITLE
Add clue history tooltip and UI labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,11 @@
 
         <div class="encryptor-card">
             <h3 id="round-counter">ROUND 01</h3>
+            <div class="card-labels">
+                <span class="label-clue">Clue</span>
+                <span class="label-guess">Team guess</span>
+                <span class="label-guess">Enemies guess</span>
+            </div>
             <div class="clue-row">
                 <input type="text" class="clue-input" placeholder="Clue 1">
                 <input type="number" class="guess-box" maxlength="1">
@@ -56,9 +61,15 @@
                 <input type="number" class="guess-box" maxlength="1">
                 <input type="number" class="guess-box" maxlength="1">
             </div>
-            <button id="new-round-button" class="clear-button">New Round</button>
+            <div class="card-actions">
+                <button id="new-round-button">New Round</button>
+                <button id="given-clues-button">Given Clues</button>
+            </div>
+
+            <div id="given-clues-tooltip" class="tooltip" style="display: none;"></div>
         </div>
 
+        <h3>Enemies leaked clues 🔎</h3>
         <div class="opponent-notes-grid">
             <div class="clue-column">
                 <h4>1</h4>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const newGameButton = document.getElementById('new-game-button');
     const tokenButtons = document.querySelectorAll('.token-button');
     const newRoundButton = document.getElementById('new-round-button');
+    const givenCluesButton = document.getElementById('given-clues-button');
+    const givenCluesTooltip = document.getElementById('given-clues-tooltip');
     const clueInputs = document.querySelectorAll('.encryptor-card .clue-input');
     const guessInputs = document.querySelectorAll('.encryptor-card .guess-box');
     const roundCounterEl = document.getElementById('round-counter');
@@ -14,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let wordBank = [];
     let roundNumber = 1;
+    let myTeamClueHistory = [];
 
     function updateRoundCounter() {
         if (roundCounterEl) {
@@ -95,12 +98,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (newRoundButton) {
         newRoundButton.addEventListener('click', () => {
+            const clues = Array.from(clueInputs).map(inp => inp.value.trim());
+            myTeamClueHistory.push({ round: roundNumber, clues });
+
             roundNumber++;
             updateRoundCounter();
             clueInputs.forEach(input => input.value = '');
             guessInputs.forEach(input => input.value = '');
             codeDisplay.style.display = 'none';
             floppyButton.style.display = 'block';
+        });
+    }
+
+    if (givenCluesButton) {
+        givenCluesButton.addEventListener('click', () => {
+            const html = myTeamClueHistory
+                .map(entry => `Round ${entry.round}: ${entry.clues.join(', ')}`)
+                .join('<br>');
+            givenCluesTooltip.innerHTML = html;
+
+            if (givenCluesTooltip.style.display === 'none' || !givenCluesTooltip.style.display) {
+                givenCluesTooltip.style.display = 'block';
+            } else {
+                givenCluesTooltip.style.display = 'none';
+            }
         });
     }
 

--- a/style.css
+++ b/style.css
@@ -196,6 +196,7 @@ body {
 
 /* --- 6. Notes / Clue History --- */
 .encryptor-card {
+    position: relative;
     padding: 15px;
     border-radius: 6px;
     margin-bottom: 25px;
@@ -213,6 +214,24 @@ body {
     text-transform: uppercase;
     opacity: 0.8;
     margin-top: 0;
+}
+
+/* New labels above clue inputs */
+.card-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.8em;
+    opacity: 0.7;
+    padding: 0 5px;
+    margin-bottom: 5px;
+}
+.card-labels .label-clue {
+    flex-grow: 1;
+}
+.card-labels .label-guess {
+    width: 35px;
+    text-align: center;
+    margin: 0 4px;
 }
 
 .clue-row {
@@ -234,6 +253,30 @@ body {
     font-family: var(--font-digital);
     font-size: 1.5em;
     padding: 0;
+}
+.card-actions {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 15px;
+}
+.card-actions button {
+    width: 48%;
+}
+
+/* Tooltip for showing past clues */
+.tooltip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #222;
+    color: #eee;
+    border: 1px solid #888;
+    border-radius: 8px;
+    padding: 15px;
+    width: 250px;
+    box-shadow: 0 -4px 15px rgba(0,0,0,0.4);
+    z-index: 10;
 }
 .encryptor-card button.clear-button {
     width: auto;


### PR DESCRIPTION
## Summary
- show clue column labels and new `Given Clues` button
- add enemy clue history title
- support tooltip listing previously given clues

## Testing
- `python decrypto.py`
- `python -m py_compile decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686dd782ca4c83278954c80c18ead92b