### PR TITLE
Apply retro-tech style updates

### DIFF
--- a/style.css
+++ b/style.css
@@ -136,6 +136,14 @@ body {
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
 }
 
+/* Retro plastic look for the white team */
+.game-console.white-team-theme {
+    background-color: #EAEAEA;
+    border: 1px solid #BDBDBD;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2),
+                inset 0px 2px 3px rgba(255, 255, 255, 0.8);
+}
+
 /* Team-specific Themes */
 .white-team-theme {
     background-color: var(--color-white-team-bg);
@@ -162,12 +170,20 @@ body {
     padding: 10px;
     font-size: 1.1em;
     position: relative;
-    padding-top: 25px;
-    border: 2px solid;
-    border-radius: 6px;
+    padding-top: 10px;
+    border: 1px solid #5C0000;
+    border-radius: 4px;
     text-align: center;
     font-weight: bold;
     text-transform: uppercase;
+    background-color: #1A0000;
+    color: var(--color-digital-red, #e50000);
+    font-family: var(--font-digital, 'Orbitron', sans-serif);
+    text-shadow: 0 0 6px var(--color-digital-red-glow, rgba(255,0,0,0.5));
+    box-shadow: inset 0 0 8px rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 /* Style for the keyword numbers */
@@ -178,9 +194,9 @@ body {
     font-size: 0.8em;
     font-weight: bold;
     opacity: 0.7;
+    display: none;
 }
-.white-team-theme .keyword-slot { border-color: var(--color-white-team-border); }
-.black-team-theme .keyword-slot { border-color: var(--color-black-team-border); }
+/* Border color handled by CRT style above */
 
 .code-display {
     background-color: #2b0000;
@@ -219,7 +235,7 @@ body {
     height: 90px;
     flex-shrink: 0;
     background-color: #555;
-    border: 2px solid #888;
+    border: 2px solid #222;
     border-radius: 4px;
     cursor: pointer;
     position: relative;
@@ -227,13 +243,25 @@ body {
 }
 .floppy-disk-button:hover { background-color: #666; }
 .floppy-disk-button::before {
+    /* metal slider */
     content: '';
     position: absolute;
-    bottom: 5px;
+    top: 8px;
     left: 10px;
     right: 10px;
-    height: 15px;
-    background-color: #ccc;
+    height: 22px;
+    background: linear-gradient(#eee, #bbb);
+    border-radius: 2px;
+}
+.floppy-disk-button::after {
+    /* paper label */
+    content: '';
+    position: absolute;
+    top: 40px;
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    background-color: #fafafa;
     border-radius: 2px;
 }
 
@@ -264,8 +292,10 @@ body {
     transition: opacity 0.2s;
 }
 .token-group .token-display.active {
-    box-shadow: 0 0 10px var(--color-digital-red-glow);
     opacity: 1;
+    background: radial-gradient(circle at 50% 40%, #FF8A8A, var(--color-digital-red));
+    box-shadow: 0 0 10px var(--color-digital-red),
+                inset 0 0 5px rgba(255,255,255,0.5);
 }
 .token-interception { background-color: var(--token-interception); }
 .token-miscommunication { background-color: var(--token-miscommunication); }


### PR DESCRIPTION
## Summary
- style white team console like retro hardware
- redesign keyword slots as red CRT screens
- enhance floppy disk button visuals
- make tokens glow like LEDs

## Testing
- `python decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686df05e3e448327982394983164671c