### PR TITLE
Integrate Workbench & Monofett fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Orbitron:wght@500&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Monofett&family=Workbench&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -36,12 +37,12 @@
 
             <div class="tokens-area">
                 <div class="token-group">
-                    <div>Interception</div>
+                    <div class="ui-special-font">Interception</div>
                     <button class="token-button"><div class="token-display token-interception"></div></button>
                     <button class="token-button"><div class="token-display token-interception"></div></button>
                 </div>
                 <div class="token-group">
-                    <div>Miscommunication</div>
+                    <div class="ui-special-font">Miscommunication</div>
                     <button class="token-button"><div class="token-display token-miscommunication"></div></button>
                     <button class="token-button"><div class="token-display token-miscommunication"></div></button>
                 </div>
@@ -49,7 +50,7 @@
         </div>
 
         <div class="encryptor-card">
-            <h3 id="round-counter">ROUND 01</h3>
+            <h3 id="round-counter" class="ui-special-font">ROUND 01</h3>
             <div class="card-labels">
                 <span class="label-clue">Clue</span>
                 <span class="label-guess">Team guess</span>
@@ -82,7 +83,7 @@
             <div id="given-clues-tooltip" class="tooltip" style="display: none;"></div>
         </div>
 
-        <h3>Enemies leaked clues 🔎</h3>
+        <h3 class="ui-special-font">Enemies leaked clues 🔎</h3>
         <div class="opponent-notes-grid">
             <div class="clue-column">
                 <h4>1</h4>

--- a/style.css
+++ b/style.css
@@ -19,6 +19,10 @@
     --font-digital: 'Orbitron', sans-serif;
     --font-handwritten: 'Kalam', cursive;
 
+    /* Fonts for retro-tech look */
+    --font-keyword: 'Workbench', sans-serif; /* For Keywords */
+    --font-ui-special: 'Monofett', monospace; /* For UI Titles */
+
     --color-background: #1a1a1a;
     --color-digital-red: #e50000;
     --color-digital-red-glow: rgba(255, 0, 0, 0.5);
@@ -160,7 +164,8 @@ body {
 .keyword-slot {
     flex-grow: 1;
     padding: 10px;
-    font-size: 1.1em;
+    font-family: var(--font-keyword); /* Use Workbench font */
+    font-size: 1.5em; /* Adjust size as needed */
     position: relative;
     padding-top: 25px;
     border: 2px solid;
@@ -168,6 +173,14 @@ body {
     text-align: center;
     font-weight: bold;
     text-transform: uppercase;
+}
+
+/* Special UI titles using Monofett */
+.ui-special-font {
+    font-family: var(--font-ui-special); /* Use Monofett font */
+    font-size: 1.2em; /* Adjust size for readability */
+    letter-spacing: 0.1em; /* Add space between characters */
+    font-weight: 100; /* Monofett is a thin font */
 }
 
 /* Style for the keyword numbers */


### PR DESCRIPTION
## Summary
- load Workbench and Monofett fonts
- use new fonts through CSS variables
- style keyword slots with Workbench
- add `.ui-special-font` for title text in Monofett
- apply the font to tokens, round counter and clues heading

## Testing
- `python -m py_compile decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686df1cc467c8327b622d33d700263a1