### PR TITLE
Add VT323 terminal font

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Digital Decrypto</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Orbitron:wght@500&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Monofett&family=VT323&family=Workbench&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>

--- a/style.css
+++ b/style.css
@@ -18,6 +18,9 @@
     --font-sans: 'Roboto', sans-serif;
     --font-digital: 'Orbitron', sans-serif;
     --font-handwritten: 'Kalam', cursive;
+    --font-keyword: 'Workbench', sans-serif;
+    --font-ui-special: 'Monofett', monospace;
+    --font-terminal: 'VT323', monospace; /* For terminal-style text */
 
     --color-background: #1a1a1a;
     --color-digital-red: #e50000;
@@ -406,8 +409,8 @@ body {
     border: none;
     border-bottom: 1px solid;
     border-radius: 0;
-    font-family: var(--font-handwritten);
-    font-size: 1.1em;
+    font-family: var(--font-terminal); /* Use VT323 font */
+    font-size: 1.2em; /* Adjust size for a classic terminal look */
     padding: 2px 5px;
     margin-bottom: 4px;
     height: 20px;


### PR DESCRIPTION
## Summary
- import new Google fonts Workbench, Monofett, and VT323
- define new `--font-terminal` CSS variable
- use the VT323 font for opponent clue text areas

## Testing
- `python -m py_compile decrypto.py`
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_686df24799108327bcd5188dc0ef18f1