### PR TITLE
Increase enemy clues title size and center text

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
             <div id="given-clues-tooltip" class="tooltip" style="display: none;"></div>
         </div>
 
-        <h3 class="ui-special-font">Enemies leaked clues 🔎</h3>
+        <h3 class="ui-special-font enemy-clues-title">Enemies leaked clues 🔎</h3>
         <div class="opponent-notes-grid">
             <div class="clue-column">
                 <h4>1</h4>

--- a/style.css
+++ b/style.css
@@ -202,6 +202,12 @@ body {
     font-weight: 100; /* Monofett is a thin font */
 }
 
+/* Larger centered title for the opponent clues section */
+.enemy-clues-title {
+    font-size: 2.4em; /* Double the default size */
+    text-align: center;
+}
+
 /* Style for the keyword numbers */
 .keyword-number {
     position: absolute;


### PR DESCRIPTION
## Summary
- enlarge the "Enemies leaked clues" header and center it

## Testing
- `python decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686df37bedc48327a2f2b4d5e43aeee3