### PR TITLE
Resize clue input columns

### DIFF
--- a/style.css
+++ b/style.css
@@ -347,38 +347,39 @@ body {
 
 /* New labels above clue inputs */
 .card-labels {
-    display: flex;
-    /* justify-content: space-between;  <-- REMOVE THIS */
-    gap: 8px; /* <-- ADD THIS (should match .clue-row) */
+    display: grid;
+    grid-template-columns: 70% 10% 10% 10%;
+    gap: 8px;
     font-size: 0.8em;
     opacity: 0.7;
     padding: 0 5px;
     margin-bottom: 5px;
 }
 .card-labels .label-clue {
-    flex-grow: 1;
+    width: 100%;
 }
 .card-labels .label-guess {
-    width: 35px;
+    width: 100%;
     text-align: center;
-    margin: 0; /* <-- REMOVE THE MARGIN */
-    flex-shrink: 0; /* Prevent labels from shrinking */
+    margin: 0;
+    flex-shrink: 0;
 }
 
 .clue-row {
-    display: flex;
+    display: grid;
+    grid-template-columns: 70% 10% 10% 10%;
     align-items: center;
     gap: 8px;
     margin-bottom: 10px;
 }
 
 .clue-row .clue-input {
-    flex-grow: 1;
+    width: 100%;
     margin: 0;
 }
 
 .guess-box {
-    width: 35px;
+    width: 100%;
     height: 35px;
     text-align: center;
     font-family: var(--font-digital);


### PR DESCRIPTION
## Summary
- tweak layout for clue inputs
- show clue inputs at 70% width and guesses at 10% each

## Testing
- `python -m py_compile decrypto.py`


------
https://chatgpt.com/codex/tasks/task_e_686e25fdf1f883278bd3184b4557d097