### PR TITLE
Increase Interception and Miscommunication label size

### DIFF
--- a/style.css
+++ b/style.css
@@ -298,7 +298,7 @@ body {
     text-align: center;
 }
 .token-group .ui-special-font {
-    font-size: 0.6em;
+    font-size: 20px;
 }
 .token-button {
     background: none;


### PR DESCRIPTION
## Summary
- enlarge the token title labels "Interception" and "Miscommunication" in the UI

## Testing
- `python decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686e29dc691c8327818170cda4292a14