### PR TITLE
Add glitch title and scanline background effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Digital Decrypto</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bungee+Shade&family=Monofett&family=VT323&family=Workbench&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bungee+Shade&family=Monofett&family=Rampart+One&family=VT323&family=Workbench&display=swap" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Orbitron:wght@500&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -19,6 +19,9 @@
             <div id="circle-xlarge"></div>
             <div id="circle-xxlarge"></div>
         </div>
+    </div>
+    <div class="title-container">
+        <h1 class="glitch" data-text="DESENCRIPTA">DESENCRIPTA</h1>
     </div>
     <div class="game-console white-team-theme">
         <button id="new-game-button" class="primary-action">New Game</button>

--- a/style.css
+++ b/style.css
@@ -611,3 +611,137 @@ button.primary-action:hover {
 .hidden {
     display: none !important;
 }
+
+/* --- Animated Glitch Title --- */
+.title-container {
+    /* Initially hidden for the reveal animation */
+    opacity: 0;
+    animation: fadeIn 0.5s ease 1.5s forwards; /* Fades in after the glitch reveal */
+}
+
+.glitch {
+    font-family: 'Rampart One', sans-serif;
+    font-size: 6vw; /* Responsive font size */
+    color: #fff;
+    position: relative;
+    letter-spacing: 0.1em;
+    text-shadow:
+        0 0 5px rgba(109, 230, 248, 0.4),
+        0 0 10px rgba(109, 230, 248, 0.4);
+
+    /* Reveal Animation */
+    animation: reveal-glitch 2s ease-out forwards;
+}
+
+/* Glitch pseudo-elements (the red/blue copies) */
+.glitch::before,
+.glitch::after {
+    content: attr(data-text); /* Uses the text from the data-text attribute */
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: transparent;
+    clip-path: inset(0 0 0 0); /* No clipping initially */
+}
+
+.glitch::before {
+    left: -2px;
+    text-shadow: 1px 0 #ff3f65; /* Magenta/Red glow */
+    animation: glitch-anim-1 2s infinite linear alternate-reverse;
+}
+
+.glitch::after {
+    left: 2px;
+    text-shadow: -1px 0 #00d8ff; /* Cyan glow */
+    animation: glitch-anim-2 2s infinite linear alternate-reverse;
+}
+
+/* --- Keyframe Animations --- */
+
+/* Glitch effect for pseudo-elements */
+@keyframes glitch-anim-1 {
+    0% { clip-path: inset(45% 0 50% 0); }
+    25% { clip-path: inset(10% 0 82% 0); }
+    50% { clip-path: inset(80% 0 5% 0); }
+    75% { clip-path: inset(40% 0 55% 0); }
+    100% { clip-path: inset(60% 0 32% 0); }
+}
+
+@keyframes glitch-anim-2 {
+    0% { clip-path: inset(15% 0 80% 0); }
+    25% { clip-path: inset(90% 0 5% 0); }
+    50% { clip-path: inset(20% 0 75% 0); }
+    75% { clip-path: inset(65% 0 20% 0); }
+    100% { clip-path: inset(30% 0 68% 0); }
+}
+
+/* Reveal animation (the "over the top" part) */
+@keyframes reveal-glitch {
+  0% { text-shadow: none; color: transparent; }
+  20% { color: #fff; text-shadow: 2px 2px #ff3f65, -2px -2px #00d8ff; }
+  60% { color: #fff; text-shadow: none; }
+  100% { color: #fff; }
+}
+
+/* Fade-in for the container after reveal */
+@keyframes fadeIn {
+  to { opacity: 1; }
+}
+
+/* --- Media Query for Wide Screens --- */
+/* On screens wider than 1024px */
+@media (min-width: 1024px) {
+    body {
+        /* Change body to allow side-by-side layout */
+        flex-direction: row;
+        justify-content: center;
+        align-items: center;
+    }
+    
+    .title-container {
+        flex-basis: 40%; /* Title takes up space */
+        text-align: right;
+        padding-right: 50px;
+    }
+
+    .game-console {
+        flex-basis: 500px; /* Fixed width for the console */
+        flex-shrink: 0;
+        margin: 0; /* Remove auto margin */
+    }
+}
+
+/* --- Fullscreen Scanline Background Effect --- */
+body::after {
+    content: "";
+    position: fixed; /* Covers the entire viewport */
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none; /* Allows clicks to go through */
+    background: linear-gradient(
+        rgba(18, 16, 16, 0) 50%,
+        rgba(0, 0, 0, 0.25) 50%
+    ), linear-gradient(
+        90deg, 
+        rgba(255, 0, 0, 0.06), 
+        rgba(0, 255, 0, 0.02), 
+        rgba(0, 0, 255, 0.06)
+    );
+    background-size: 100% 4px, 100% 100%;
+    z-index: 3000; /* Must be on top of everything, including the title */
+    animation: scanline-anim 15s linear infinite;
+}
+
+/* Animates the scanlines moving down the screen */
+@keyframes scanline-anim {
+    from {
+        background-position: 0 0;
+    }
+    to {
+        background-position: 0 -100vh;
+    }
+}


### PR DESCRIPTION
## Summary
- update Google Fonts link to include Rampart One
- add DESENCRIPTA glitch title HTML
- implement glitch title animation and wide screen layout
- add fullscreen scanline background effect

## Testing
- `python -m py_compile decrypto.py`


------
https://chatgpt.com/codex/tasks/task_e_686e2bc4565c8327b4518e66f5449f67