### PR TITLE
Improve mobile and desktop layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,36 +20,17 @@
             <div id="circle-xxlarge"></div>
         </div>
     </div>
-    <div class="title-container">
-        <h1 class="glitch" data-text="DESENCRIPTA">DESENCRIPTA</h1>
-    </div>
-    <div class="game-console white-team-theme">
-        <button id="new-game-button" class="primary-action">New Game</button>
-        <button id="how-to-play-button">How to Play</button>
-
-        <div id="how-to-play-modal" class="modal-overlay hidden">
-            <div class="modal-content">
-                <button class="modal-close-button">&times;</button>
-                <h2>How to Play</h2>
-                
-                <h4>The Goal</h4>
-                <p>Your team wins by guessing the other team's code twice (<b>2 Interception Tokens</b>). You lose if you miss your own code twice (<b>2 Miscommunication Tokens</b>).</p>
-                
-                <h4>Gameplay Loop (each round)</h4>
-                <ol>
-
-                    <li>One player on your team, the <strong>Encryptor</strong>, gets a secret 3-digit code (e.g., 4-1-2) by clicking in the disquette 💾.</li>
-                    <li>The Encryptor writes and gives three clues aloud, one for each keyword corresponding to the code.</li>
-                    <li>Both teams try to guess the secret code. Interceptions are only allowed from Round 2 onwards (In the first round only the Encryptors team will guess).</li>
-                    <li>After guesses are revealed, tokens are awarded ⚪⚫ and you must write down the opponent's clues in the correct columns on your sheet.</li>
-
-                </ol>
-
-                <p class="attribution">
-                    This is a fan-made project based on the board game <strong>DECRYPTO</strong>. If you enjoy it, please support the creators by buying the original game!
-                </p>
-            </div>
+    <header class="main-header">
+        <div class="title-container">
+            <h1 class="glitch" data-text="DESENCRIPTA">DESENCRIPTA</h1>
         </div>
+        <div class="header-buttons">
+            <button id="how-to-play-button">How to Play</button>
+            <button id="new-game-button" class="primary-action">New Game</button>
+        </div>
+    </header>
+
+    <div class="game-console white-team-theme">
         <div class="keywords-container">
             <div class="keyword-slot"><span class="keyword-number">1</span></div>
             <div class="keyword-slot"><span class="keyword-number">2</span></div>
@@ -164,6 +145,31 @@
             </div>
         </div>
     </div>
+
+    <div id="how-to-play-modal" class="modal-overlay hidden">
+        <div class="modal-content">
+            <button class="modal-close-button">&times;</button>
+            <h2>How to Play</h2>
+
+            <h4>The Goal</h4>
+            <p>Your team wins by guessing the other team's code twice (<b>2 Interception Tokens</b>). You lose if you miss your own code twice (<b>2 Miscommunication Tokens</b>).</p>
+
+            <h4>Gameplay Loop (each round)</h4>
+            <ol>
+
+                <li>One player on your team, the <strong>Encryptor</strong>, gets a secret 3-digit code (e.g., 4-1-2) by clicking in the disquette 💾.</li>
+                <li>The Encryptor writes and gives three clues aloud, one for each keyword corresponding to the code.</li>
+                <li>Both teams try to guess the secret code. Interceptions are only allowed from Round 2 onwards (In the first round only the Encryptors team will guess).</li>
+                <li>After guesses are revealed, tokens are awarded ⚪⚫ and you must write down the opponent's clues in the correct columns on your sheet.</li>
+
+            </ol>
+
+            <p class="attribution">
+                This is a fan-made project based on the board game <strong>DECRYPTO</strong>. If you enjoy it, please support the creators by buying the original game!
+            </p>
+        </div>
+    </div>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -552,14 +552,10 @@ button.primary-action:hover {
     border-color: #222;
 }
 
-/* Persistent new game button */
+/* Base style for the main action button */
 #new-game-button {
-    position: fixed;
-    top: 20px;
-    right: 20px;
     width: auto;
     padding: 10px 20px;
-    z-index: 1000;
     font-size: 1em;
 }
 
@@ -575,16 +571,11 @@ button.primary-action:hover {
 
 /* --- "How to Play" Button --- */
 #how-to-play-button {
-    /* Place the button directly below the New Game button */
-    position: fixed;
-    top: 70px;
-    right: 20px;
     width: auto;
     padding: 8px 15px;
     font-size: 0.8em;
     background-color: #555;
     color: white;
-    z-index: 1000;
 }
 
 #how-to-play-button:hover {
@@ -736,22 +727,121 @@ button.primary-action:hover {
 /* On screens wider than 1024px */
 @media (min-width: 1024px) {
     body {
-        /* Change body to allow side-by-side layout */
-        flex-direction: row;
-        justify-content: center;
-        align-items: center;
+        position: relative;
+        overflow-x: hidden;
     }
-    
+
+    .main-header {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+    }
+
     .title-container {
-        flex-basis: 40%; /* Title takes up space */
-        text-align: right;
-        padding-right: 50px;
+        position: absolute;
+        top: 50%;
+        left: 5%;
+        transform: translateY(-50%) rotate(-15deg);
+        transform-origin: center;
+    }
+
+    .glitch {
+        font-size: 5vw;
+    }
+
+    .header-buttons {
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        display: flex;
+        gap: 10px;
+        pointer-events: auto;
+    }
+
+
+    .game-console {
+        margin: auto;
+    }
+}
+
+/* --- MOBILE & TABLET LAYOUT --- */
+@media (max-width: 1023px) {
+    body {
+        padding: 10px;
+        display: block;
+    }
+
+    .main-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 15px;
+    }
+
+    .title-container {
+        transform: none;
+        padding: 0;
+        flex-grow: 1;
+    }
+
+    .glitch {
+        font-size: 8vw;
+        text-align: left;
+    }
+
+    .header-buttons {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    #new-game-button, #how-to-play-button {
+        position: static;
+        width: 100px;
+        font-size: 0.7em;
+        padding: 8px;
     }
 
     .game-console {
-        flex-basis: 500px; /* Fixed width for the console */
-        flex-shrink: 0;
-        margin: 0; /* Remove auto margin */
+        width: 100%;
+        padding: 15px;
+        box-sizing: border-box;
+    }
+
+    .keyword-slot {
+        font-size: 0.9em;
+        padding: 8px 4px;
+        min-height: 40px;
+    }
+
+    .clue-row {
+        gap: 5px;
+    }
+    .clue-input {
+        padding: 8px;
+        font-size: 0.9em;
+    }
+    .guess-box {
+        width: 30px;
+        height: 30px;
+        font-size: 1.2em;
+    }
+    .card-labels .label-guess {
+        width: 30px;
+    }
+
+    .opponent-notes-grid {
+        gap: 5px;
+    }
+    .opponent-notes-grid .clue-column textarea {
+        height: 18px;
+        font-size: 1em;
+    }
+    .round-labels-column {
+        font-size: 0.8em;
     }
 }
 


### PR DESCRIPTION
## Summary
- group header content in `main-header`
- move how-to-play modal outside the game console
- style new header layout for wide screens
- add mobile media query for a compact layout

## Testing
- `python3 -m py_compile decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686e45b2987483279f8ac707963d009b