### PR TITLE
Add terminal font to clue labels

### DIFF
--- a/style.css
+++ b/style.css
@@ -384,6 +384,9 @@ body {
     padding: 0 5px;
     margin-bottom: 5px;
 }
+.card-labels span {
+    font-family: var(--font-terminal);
+}
 .card-labels .label-clue {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- use VT323 terminal font for clue headers in the encryptor card

## Testing
- `python decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686f116502048327bfb3ac1b73c218f1