### PR TITLE
Fix header spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,9 +65,9 @@
             <h3 id="round-counter" class="ui-special-font">ROUND 01</h3>
             <div class="card-labels">
                 <span class="label-clue">Clue</span>
-                <span class="label-guess">Team guess</span>
-                <span class="label-guess">Enemies guess</span>
-                <span class="label-guess">Correct Answer</span>
+                <span class="label-guess">TeamGuess</span>
+                <span class="label-guess">EnemiesGuess</span>
+                <span class="label-guess">CorrectAnswer</span>
             </div>
             <div class="clue-row">
                 <input type="text" class="clue-input" placeholder="Clue 1">

--- a/style.css
+++ b/style.css
@@ -378,11 +378,15 @@ body {
 .card-labels {
     display: grid;
     grid-template-columns: 70% 10% 10% 10%;
-    gap: 8px;
+    gap: 0;
     font-size: 0.8em;
     opacity: 0.7;
     padding: 0 5px;
     margin-bottom: 5px;
+}
+.card-labels span {
+    font-family: var(--font-terminal);
+    text-transform: uppercase;
 }
 .card-labels .label-clue {
     width: 100%;


### PR DESCRIPTION
## Summary
- shrink spacing in card labels
- add retro font to clue headers
- tweak labels to remove spaces

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f0e83794083278d3d8e128cfd4601