### PR TITLE
Fix enemy clues spacing for R1

### DIFF
--- a/style.css
+++ b/style.css
@@ -489,7 +489,7 @@ body {
 .clue-column {
     border: 2px solid;
     border-radius: 6px;
-    padding: 10px;
+    padding: 5px; /* reduce internal spacing */
     min-height: 150px;
 }
 .white-team-theme .clue-column { border-color: var(--color-white-team-border); }
@@ -497,6 +497,7 @@ body {
 
 .clue-column h4 {
     margin-top: 0;
+    margin-bottom: 0; /* Ensure consistent spacing for R1 textareas */
     border-bottom: 1px solid;
     padding-bottom: 5px;
     font-family: var(--font-keyword);


### PR DESCRIPTION
## Summary
- tighten spacing above round R1 enemy notes so the first textarea matches the others
- reduce clue column padding for a more compact layout

## Testing
- `python decrypto.py`


------
https://chatgpt.com/codex/tasks/task_e_686f1073e1708327a630bce3d6fe2c82