### PR TITLE
Fix R1 alignment in enemies table

### DIFF
--- a/style.css
+++ b/style.css
@@ -468,6 +468,10 @@ body {
     color: #888;
     padding: 10px 5px;
 }
+/* Align the first round label with the top row of clues */
+.round-labels-column span:first-child {
+    margin-top: 6px;
+}
 .opponent-notes-grid .clue-column textarea {
     width: 100%;
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- tweak CSS for round labels so R1 aligns with first clue row

## Testing
- `python decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686f2007a25483279f70e2642aa82d61