### PR TITLE
Reduce code display font

### DIFF
--- a/style.css
+++ b/style.css
@@ -225,7 +225,7 @@ body {
     font-family: var(--font-digital);
     color: var(--color-digital-red);
     text-shadow: 0 0 8px var(--color-digital-red-glow);
-    font-size: 2.5em;
+    font-size: 1.75em; /* Reduced 30% for smaller code digits */
     text-align: center;
     padding: 20px;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- adjust `.code-display` font size to shrink the digits shown when clicking the floppy disk

## Testing
- `python3 decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686f25bd08808327913c939057f6b245