### PR TITLE
Add round column

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,9 @@
         <h3 class="ui-special-font enemy-clues-title">Enemies leaked clues 🔎</h3>
         <div class="opponent-notes-grid">
             <div class="round-labels-column">
-                <span>R1</span><span>R2</span><span>R3</span><span>R4</span>
-                <span>R5</span><span>R6</span><span>R7</span><span>R8</span>
+                <h4>Ronda</h4>
+                <span>1</span><span>2</span><span>3</span><span>4</span>
+                <span>5</span><span>6</span><span>7</span><span>8</span>
             </div>
 
             <div class="clue-column">

--- a/style.css
+++ b/style.css
@@ -453,7 +453,7 @@ body {
 
 .opponent-notes-grid {
     display: grid;
-    grid-template-columns: auto repeat(4, 1fr);
+    grid-template-columns: 40px repeat(4, 1fr);
     gap: 8px;
     text-align: center;
 }
@@ -467,9 +467,19 @@ body {
     font-size: 1em;
     color: #888;
     padding: 10px 5px;
+    width: 40px;
 }
+.round-labels-column h4 {
+    margin: 0;
+    border-bottom: 1px solid;
+    padding-bottom: 5px;
+    font-family: var(--font-keyword);
+    font-size: 1.2em;
+}
+.white-team-theme .round-labels-column h4 { border-color: var(--color-white-team-border); }
+.black-team-theme .round-labels-column h4 { border-color: var(--color-black-team-border); }
 /* Align the first round label with the top row of clues */
-.round-labels-column span:first-child {
+.round-labels-column span:first-of-type {
     margin-top: 6px;
 }
 .opponent-notes-grid .clue-column textarea {
@@ -878,6 +888,7 @@ button.primary-action:hover {
     }
     .round-labels-column {
         font-size: 0.8em;
+        width: 30px;
     }
 }
 


### PR DESCRIPTION
## Summary
- add a "Ronda" column with round numbers in the opponent notes grid
- style the new column

## Testing
- `python -m py_compile decrypto.py`

------
https://chatgpt.com/codex/tasks/task_e_686f27cdd9c88327ba1a55f53166b50c