### PR TITLE
Update opponent notes layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,55 +97,50 @@
 
         <h3 class="ui-special-font enemy-clues-title">Enemies leaked clues 🔎</h3>
         <div class="opponent-notes-grid">
-            <div class="round-labels-column">
-                <h4>Ronda</h4>
-                <span>1</span><span>2</span><span>3</span><span>4</span>
-                <span>5</span><span>6</span><span>7</span><span>8</span>
-            </div>
 
             <div class="clue-column">
                 <h4>1</h4>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
+                <div class="note-row"><span class="note-number">1.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">2.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">3.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">4.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">5.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">6.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">7.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">8.</span><textarea></textarea></div>
             </div>
             <div class="clue-column">
                 <h4>2</h4>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
+                <div class="note-row"><span class="note-number">1.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">2.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">3.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">4.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">5.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">6.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">7.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">8.</span><textarea></textarea></div>
             </div>
             <div class="clue-column">
                 <h4>3</h4>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
+                <div class="note-row"><span class="note-number">1.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">2.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">3.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">4.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">5.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">6.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">7.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">8.</span><textarea></textarea></div>
             </div>
             <div class="clue-column">
                 <h4>4</h4>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
-                <textarea></textarea>
+                <div class="note-row"><span class="note-number">1.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">2.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">3.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">4.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">5.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">6.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">7.</span><textarea></textarea></div>
+                <div class="note-row"><span class="note-number">8.</span><textarea></textarea></div>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -453,35 +453,11 @@ body {
 
 .opponent-notes-grid {
     display: grid;
-    grid-template-columns: 40px repeat(4, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     gap: 8px;
     text-align: center;
 }
 
-/* NEW: Style for the round labels column */
-.round-labels-column {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-    font-family: var(--font-terminal);
-    font-size: 1em;
-    color: #888;
-    padding: 10px 5px;
-    width: 40px;
-}
-.round-labels-column h4 {
-    margin: 0;
-    border-bottom: 1px solid;
-    padding-bottom: 5px;
-    font-family: var(--font-keyword);
-    font-size: 1.2em;
-}
-.white-team-theme .round-labels-column h4 { border-color: var(--color-white-team-border); }
-.black-team-theme .round-labels-column h4 { border-color: var(--color-black-team-border); }
-/* Align the first round label with the top row of clues */
-.round-labels-column span:first-of-type {
-    margin-top: 6px;
-}
 .opponent-notes-grid .clue-column textarea {
     width: 100%;
     box-sizing: border-box;
@@ -524,6 +500,19 @@ body {
 }
 .white-team-theme .clue-column h4 { border-color: var(--color-white-team-border); }
 .black-team-theme .clue-column h4 { border-color: var(--color-black-team-border); }
+
+.note-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.note-number {
+    width: 1.2em;
+    flex-shrink: 0;
+    font-family: var(--font-terminal);
+    color: #888;
+}
 
 .clue-item {
     font-family: var(--font-handwritten);
@@ -885,10 +874,6 @@ button.primary-action:hover {
     .opponent-notes-grid .clue-column textarea {
         height: 18px;
         font-size: 1em;
-    }
-    .round-labels-column {
-        font-size: 0.8em;
-        width: 30px;
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the round number column
- number each enemy clue row in all four columns
- adjust layout and add styles for numbered rows

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f3a945f2c8327b6dfaf4080aa15fc