### PR TITLE
Implement splash screen logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Kalam:wght@400;700&family=Orbitron:wght@500&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="splash-active">
     <div id="gradient-container">
         <div id="container-inside">
             <div id="circle-small"></div>
@@ -30,7 +30,7 @@
         </div>
     </header>
 
-    <div class="game-console white-team-theme">
+    <div class="game-console white-team-theme hidden">
         <div class="keywords-container">
             <div class="keyword-slot"><span class="keyword-number">1</span></div>
             <div class="keyword-slot"><span class="keyword-number">2</span></div>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const floppyButton = document.querySelector('.floppy-disk-button');
     const codeDisplay = document.querySelector('.code-display');
     const newGameButton = document.getElementById('new-game-button');
+    const bodyElement = document.body;
+    const gameConsole = document.querySelector('.game-console');
     const tokenButtons = document.querySelectorAll('.token-button');
     const newRoundButton = document.getElementById('new-round-button');
     const givenCluesButton = document.getElementById('given-clues-button');
@@ -29,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let wordBank = [];
     let roundNumber = 1;
     let myTeamClueHistory = [];
+    let isGameStarted = false;
 
     function randomColor() {
         const h = Math.floor(Math.random() * 360);
@@ -183,8 +186,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (newGameButton && settingsModal) {
         newGameButton.addEventListener('click', async () => {
-            await setupSettings();
-            settingsModal.classList.remove('hidden');
+            if (!isGameStarted) {
+                bodyElement.classList.remove('splash-active');
+                gameConsole.classList.remove('hidden');
+                isGameStarted = true;
+                setTimeout(async () => {
+                    await setupSettings();
+                    settingsModal.classList.remove('hidden');
+                }, 800);
+            } else {
+                await setupSettings();
+                settingsModal.classList.remove('hidden');
+            }
         });
     }
 
@@ -218,6 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             settingsModal.classList.add('hidden');
+            gameConsole.classList.remove('hidden');
             startNewGame(filteredWords.map(item => item.word));
         });
     }

--- a/style.css
+++ b/style.css
@@ -129,6 +129,42 @@ body {
     animation-delay: 1.2s;
 }
 
+/* --- Splash Screen Transition Elements --- */
+.title-container, .glitch, .header-buttons {
+    transition: all 0.8s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.game-console {
+    transition: opacity 0.5s ease 0.5s; /* Fade in after a delay */
+}
+
+/* --- Splash Screen Active Styles --- */
+.splash-active {
+    overflow: hidden; /* Hide scrollbars on splash */
+}
+
+/* Center the header container on the splash screen */
+.splash-active .main-header {
+    flex-direction: column;
+    justify-content: center;
+    height: 100vh;
+}
+
+/* Center and enlarge the title */
+.splash-active .glitch {
+    font-size: 10vw; /* Large title on splash */
+    text-align: center;
+    transform: none; /* No rotation on splash */
+}
+
+/* Position buttons below the title */
+.splash-active .header-buttons {
+    position: static; /* Not absolutely positioned on splash */
+    flex-direction: row;
+    gap: 20px;
+    margin-top: 30px;
+}
+
 /* --- 3. Main Game Console / Screen --- */
 .game-console {
     /* We need to ensure the console has a z-index to stay on top */


### PR DESCRIPTION
## Summary
- show splash screen on initial load and hide game console until New Game pressed
- style splash screen with transitions on title and buttons
- reveal console after transition via JavaScript state management

## Testing
- `python3 -m py_compile decrypto.py`
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_686f3c445ad483279299d69b43d2464e