### PR TITLE
Improve mobile splash layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -917,6 +917,22 @@ button.primary-action:hover {
         display: block;
     }
 
+    /* Center splash content on mobile */
+    body.splash-active {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+    }
+
+    body.splash-active .main-header {
+        height: auto;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
+
     .main-header {
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
## Summary
- center header and buttons on splash screen when viewed on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f4274d18c8327acea471e5bb3896e