### PR TITLE
Adjust mobile token label size

### DIFF
--- a/style.css
+++ b/style.css
@@ -959,6 +959,9 @@ button.primary-action:hover {
         padding: 8px 4px;
         min-height: 40px;
     }
+    .token-column .token-label {
+        font-size: 0.63em;
+    }
 
     .clue-row {
         gap: 0;


### PR DESCRIPTION
## Summary
- reduce the Interception and Miscommunication label font size for mobile view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f42ecfa7483278f6229f5d95a9ecc